### PR TITLE
Upgrade to camel4.8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ buildscript {
         mavenCentral()
         maven { url "https://plugins.gradle.org/m2/" }
     }
-  dependencies { classpath 'com.github.ben-manes:gradle-versions-plugin:0.42.0' }
+  dependencies { classpath 'com.github.ben-manes:gradle-versions-plugin:0.51.0' }
 }
 dependencyUpdates.resolutionStrategy = { componentSelection { rules -> rules.all { ComponentSelection selection ->
     boolean rejected = ['alpha', 'beta', 'rc', 'cr', 'm', 'b'].any { qualifier -> selection.candidate.version ==~ /(?i).*[.-]${qualifier}[.\d-].*/ }
@@ -50,15 +50,15 @@ dependencies {
     // NOTE: there is a classloading issue with Camel 2.24.0 with the default Caffeine cache so not updating for now
     // "Caused by: java.lang.ClassNotFoundException: Class org.apache.camel.com.github.benmanes.caffeine.cache.SSLMS not found."
     // NOTE: updating to Camel 3 will require various code changes...
-    implementation 'org.apache.camel:camel-core:2.22.5' // Apache 2.0
-    runtimeOnly 'org.apache.camel:camel-csv:2.22.5' // Apache 2.0
-    runtimeOnly 'org.apache.camel:camel-freemarker:2.22.5' // Apache 2.0
+    implementation 'org.apache.camel:camel-core:4.8.0' // Apache 2.0
+    runtimeOnly 'org.apache.camel:camel-csv:4.8.0' // Apache 2.0
+    //runtimeOnly 'org.apache.camel:camel-freemarker:4.8.8' // Apache 2.0
     // module for camel-groovy because depends on groovy-all and moqui-framework now using selected groovy modules
-    runtimeOnly module('org.apache.camel:camel-groovy:2.22.5') // Apache 2.0
-    /* Uncomment these as desired for use in Camel:
-    runtimeOnly ('org.apache.camel:camel-http-common:2.22.5') { exclude group: 'org.apache.geronimo.specs' } // Apache 2.0
-    runtimeOnly 'org.apache.camel:camel-http4:2.22.5' // Apache 2.0
-    runtimeOnly 'org.apache.camel:camel-jms:2.22.5' // Apache 2.0
+    runtimeOnly module('org.apache.camel:camel-groovy:4.8.0') // Apache 2.0
+    /* Uncomment these as desired for use in Camel: */
+    runtimeOnly ('org.apache.camel:camel-http-common:4.8.0') { exclude group: 'org.apache.geronimo.specs' } // Apache 2.0
+    runtimeOnly 'org.apache.camel:camel-http:4.8.0' // Apache 2.0
+ /*   runtimeOnly 'org.apache.camel:camel-jms:2.22.5' // Apache 2.0
     runtimeOnly 'org.apache.camel:camel-lucene:2.22.5' // Apache 2.0
     runtimeOnly 'org.apache.camel:camel-lucene:2.22.5' // Apache 2.0
     runtimeOnly 'org.apache.camel:camel-mail:2.22.5' // Apache 2.0

--- a/service/moqui/camel/CamelTestServices.xml
+++ b/service/moqui/camel/CamelTestServices.xml
@@ -12,19 +12,45 @@ You should have received a copy of the CC0 Public Domain Dedication
 along with this software (see the LICENSE.md file). If not, see
 <http://creativecommons.org/publicdomain/zero/1.0/>.
 -->
-<services xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://moqui.org/xsd/service-definition-3.xsd">
+<services xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="http://moqui.org/xsd/service-definition-3.xsd">
 
-    <!-- Example Camel services (one to call through Moqui Service Facade, one to be called when that service is called) -->
-    <service verb="localCamelExample" type="camel" location="moquiservice:moqui.camel.CamelTestServices.targetCamelExample">
-        <in-parameters><parameter name="testInput"/></in-parameters>
-        <out-parameters><parameter name="testOutput"/></out-parameters>
+    <!-- Example Camel services (one to call through Moqui Service Facade, one to be called when
+    that service is called) -->
+    <service verb="localCamelExample" type="camel"
+        location="moquiservice:moqui.camel.CamelTestServices.targetCamelExample">
+        <in-parameters>
+            <parameter name="testInput" />
+        </in-parameters>
+        <out-parameters>
+            <parameter name="testOutput" />
+        </out-parameters>
     </service>
     <service verb="targetCamelExample">
-        <in-parameters><parameter name="testInput"/></in-parameters>
-        <out-parameters><parameter name="testOutput"/></out-parameters>
+        <in-parameters>
+            <parameter name="testInput" />
+        </in-parameters>
+        <out-parameters>
+            <parameter name="testOutput" />
+        </out-parameters>
         <actions>
-            <set field="testOutput" value="Input was: ${testInput}"/>
-            <log level="info" message="targetCamelExample testOutput: '${testOutput}'"/>
+            <set field="testOutput" value="Input was: ${testInput}" />
+            <log level="info" message="targetCamelExample testOutput: '${testOutput}'" />
         </actions>
     </service>
+
+    <service verb="get" noun="Rest" type="java"
+        location="org.moqui.impl.service.camel.CamelRestServices"
+        method="get">
+        <description>General rest services using Camel</description>
+        <in-parameters>
+            <parameter name="url" />
+        </in-parameters>
+        <out-parameters>
+            <parameter name="result" type="Map">
+                <parameter name="response" />
+            </parameter>
+        </out-parameters>
+    </service>
+
 </services>

--- a/src/main/groovy/org/moqui/impl/service/camel/MoquiServiceComponent.groovy
+++ b/src/main/groovy/org/moqui/impl/service/camel/MoquiServiceComponent.groovy
@@ -14,7 +14,7 @@
 package org.moqui.impl.service.camel
 
 import org.apache.camel.Endpoint
-import org.apache.camel.impl.DefaultComponent
+import org.apache.camel.support.*
 
 class MoquiServiceComponent extends DefaultComponent {
 

--- a/src/main/groovy/org/moqui/impl/service/camel/MoquiServiceConsumer.groovy
+++ b/src/main/groovy/org/moqui/impl/service/camel/MoquiServiceConsumer.groovy
@@ -16,7 +16,7 @@ package org.moqui.impl.service.camel
 import org.apache.camel.Exchange
 import org.apache.camel.Processor
 import org.apache.camel.RuntimeCamelException
-import org.apache.camel.impl.DefaultConsumer
+import org.apache.camel.support.*
 import org.moqui.impl.service.ServiceDefinition
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory

--- a/src/main/groovy/org/moqui/impl/service/camel/MoquiServiceEndpoint.groovy
+++ b/src/main/groovy/org/moqui/impl/service/camel/MoquiServiceEndpoint.groovy
@@ -16,7 +16,7 @@ package org.moqui.impl.service.camel
 import org.apache.camel.Consumer
 import org.apache.camel.Processor
 import org.apache.camel.Producer
-import org.apache.camel.impl.DefaultEndpoint
+import org.apache.camel.support.DefaultEndpoint
 
 class MoquiServiceEndpoint extends DefaultEndpoint {
     protected String remaining

--- a/src/main/groovy/org/moqui/impl/service/camel/MoquiServiceProducer.groovy
+++ b/src/main/groovy/org/moqui/impl/service/camel/MoquiServiceProducer.groovy
@@ -14,7 +14,7 @@
 package org.moqui.impl.service.camel
 
 import org.apache.camel.Exchange
-import org.apache.camel.impl.DefaultProducer
+import org.apache.camel.support.*
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 


### PR DESCRIPTION
This is an untested upgrade because:
1. the http plugin required java 17
2. Moqui is not yet ready for Java17 because of:
cannot execute ManagementRegisterCommand on object with name bitronix.tm:type=JDBC,UniqueName=transactional_DS,Id=0
javax.management.InstanceAlreadyExistsException: bitronix.tm:type=JDBC,UniqueName=transactional_DS,Id=0

this happens both on h2 ,derby and progresql 14

would be nice if the experts could have a look at this because the camel is needed for a new project.