### PR TITLE
Upgrade to Apache Camel 4.16.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,4 +15,4 @@ The Apache Camel and dependent JAR files are added to the lib directory when the
 designed to be done from the Moqui build (ie from the moqui root directory) along with all other component builds. 
 
 To use just install this component. The configuration for the ToolFactory and ServiceRunner is already in place in the 
-MoquiConf.xml included in this component and will be merged with the main configuration at runtime. 
+MoquiConf.xml included in this component and will be merged with the main configuration at runtime.

--- a/build.gradle
+++ b/build.gradle
@@ -34,27 +34,28 @@ dependencies {
     testImplementation project(':framework').configurations.testImplementation.allDependencies
 
     // Apache Camel
-    // NOTE: there is a classloading issue with Camel 2.24.0 with the default Caffeine cache so not updating for now
-    // "Caused by: java.lang.ClassNotFoundException: Class org.apache.camel.com.github.benmanes.caffeine.cache.SSLMS not found."
-    // NOTE: updating to Camel 3 will require various code changes...
     implementation 'org.apache.camel:camel-core:4.16.0' // Apache 2.0
+
+    /* Uncomment these as desired for use in Camel:
     runtimeOnly 'org.apache.camel:camel-csv:4.16.0' // Apache 2.0
     runtimeOnly 'org.apache.camel:camel-freemarker:4.16.0' // Apache 2.0
-    // module for camel-groovy because depends on groovy-all and moqui-framework now using selected groovy modules
+    // camel-groovy: exclude transitive deps to avoid pulling groovy-all (Moqui uses selected groovy modules).
+    // camel-attachments must be declared explicitly because transitive=false drops it, but GroovyLanguage requires it.
     runtimeOnly('org.apache.camel:camel-groovy:4.16.0') {
         transitive = false
     } // Apache 2.0
-    /* Uncomment these as desired for use in Camel:
-    runtimeOnly ('org.apache.camel:camel-http-common:2.22.5') { exclude group: 'org.apache.geronimo.specs' } // Apache 2.0
-    runtimeOnly 'org.apache.camel:camel-http4:2.22.5' // Apache 2.0
-    runtimeOnly 'org.apache.camel:camel-jms:2.22.5' // Apache 2.0
-    runtimeOnly 'org.apache.camel:camel-lucene:2.22.5' // Apache 2.0
-    runtimeOnly 'org.apache.camel:camel-lucene:2.22.5' // Apache 2.0
-    runtimeOnly 'org.apache.camel:camel-mail:2.22.5' // Apache 2.0
-    runtimeOnly 'org.apache.camel:camel-mqtt:2.22.5' // Apache 2.0
-    runtimeOnly 'org.apache.camel:camel-quartz2:2.22.5' // Apache 2.0
-    runtimeOnly 'org.apache.camel:camel-shiro:2.22.5' // Apache 2.0
-    runtimeOnly 'org.apache.camel:camel-xmlrpc:2.22.5' // Apache 2.0
+    runtimeOnly 'org.apache.camel:camel-attachments:4.16.0' // Apache 2.0 - required by GroovyLanguage at runtime
+    runtimeOnly 'org.apache.camel:camel-jms:4.16.0'
+    runtimeOnly 'org.apache.activemq:artemis-jakarta-client:2.38.0'
+    runtimeOnly 'org.apache.camel:camel-jackson:4.16.0' // Apache 2.0
+    runtimeOnly 'org.apache.camel:camel-paho:4.16.0' // Apache 2.0
+    runtimeOnly 'org.apache.camel:camel-paho-mqtt5:4.16.0' // Apache 2.0
+    runtimeOnly 'org.apache.camel:camel-sql:4.16.0' // Apache 2.0
+    runtimeOnly ('org.apache.camel:camel-http-common:4.16.0') { exclude group: 'org.apache.geronimo.specs' } 
+    runtimeOnly 'org.apache.camel:camel-http:4.16.0'
+    runtimeOnly 'org.apache.camel:camel-lucene:4.16.0'
+    runtimeOnly 'org.apache.camel:camel-mail:4.16.0' 
+    runtimeOnly 'org.apache.camel:camel-quartz:4.16.0'
     */
 }
 
@@ -79,6 +80,7 @@ tasks.register('copyDependencies', Copy) {
 jar.dependsOn copyDependencies
 
 test {
+    dependsOn jar
     dependsOn cleanTest
     useJUnitPlatform()
 

--- a/src/main/groovy/org/moqui/impl/service/camel/CamelToolFactory.groovy
+++ b/src/main/groovy/org/moqui/impl/service/camel/CamelToolFactory.groovy
@@ -13,9 +13,11 @@
  */
 package org.moqui.impl.service.camel
 
+import java.util.concurrent.ConcurrentHashMap
 import groovy.transform.CompileStatic
 import org.apache.camel.CamelContext
 import org.apache.camel.impl.DefaultCamelContext
+import org.apache.camel.support.SimpleRegistry
 import org.moqui.context.ExecutionContextFactory
 import org.moqui.context.ToolFactory
 import org.slf4j.Logger
@@ -31,26 +33,34 @@ class CamelToolFactory implements ToolFactory<CamelContext> {
     protected ExecutionContextFactory ecf = null
     /** The central object of the Camel API: CamelContext */
     protected CamelContext camelContext
+    protected SimpleRegistry camelRegistry
     protected MoquiServiceComponent moquiServiceComponent
-    protected Map<String, MoquiServiceConsumer> camelConsumerByUriMap = new HashMap<String, MoquiServiceConsumer>()
+    protected Map<String, MoquiServiceConsumer> camelConsumerByUriMap = new ConcurrentHashMap<>()
 
     /** Default empty constructor */
     CamelToolFactory() { }
 
     @Override
     String getName() { return TOOL_NAME }
+
     @Override
     void init(ExecutionContextFactory ecf) {
         logger.info("Starting Camel")
+        if (this.ecf == null) this.ecf = ecf
+        if (camelRegistry == null) camelRegistry = new SimpleRegistry()
+        if (camelContext == null) camelContext = new DefaultCamelContext(camelRegistry)
+        configureCamelRegistry()
         moquiServiceComponent = new MoquiServiceComponent(this)
         camelContext.addComponent("moquiservice", moquiServiceComponent)
         camelContext.start()
     }
+    
     @Override
     void preFacadeInit(ExecutionContextFactory ecf) {
         this.ecf = ecf
         // setup the CamelContext, but don't init moquiservice Camel Component yet
-        camelContext = new DefaultCamelContext()
+        camelRegistry = new SimpleRegistry()
+        camelContext = new DefaultCamelContext(camelRegistry)
     }
 
     @Override
@@ -69,4 +79,9 @@ class CamelToolFactory implements ToolFactory<CamelContext> {
     MoquiServiceComponent getMoquiServiceComponent() { return moquiServiceComponent }
     void registerCamelConsumer(String uri, MoquiServiceConsumer consumer) { camelConsumerByUriMap.put(uri, consumer) }
     MoquiServiceConsumer getCamelConsumer(String uri) { return camelConsumerByUriMap.get(uri) }
+
+    protected void configureCamelRegistry() {
+        camelRegistry.bind("moquiExecutionContextFactory", ExecutionContextFactory.class, ecf)
+        camelRegistry.bind("camelToolFactory", CamelToolFactory.class, this)
+    }
 }

--- a/src/main/groovy/org/moqui/impl/service/camel/MoquiServiceComponent.groovy
+++ b/src/main/groovy/org/moqui/impl/service/camel/MoquiServiceComponent.groovy
@@ -14,19 +14,25 @@
 package org.moqui.impl.service.camel
 
 import org.apache.camel.Endpoint
+import org.apache.camel.spi.annotations.Component
 import org.apache.camel.support.DefaultComponent
 
+@Component("moquiservice")
 class MoquiServiceComponent extends DefaultComponent {
 
-    protected CamelToolFactory camelToolFactory
+    protected final CamelToolFactory camelToolFactory
 
     MoquiServiceComponent(CamelToolFactory ctf) {
         super()
-        camelToolFactory = ctf
+        if (ctf == null) throw new IllegalArgumentException("CamelToolFactory cannot be null")
+        this.camelToolFactory = ctf
     }
 
+    @Override
     protected Endpoint createEndpoint(String uri, String remaining, Map<String, Object> parameters) throws Exception {
+        if (!remaining) throw new IllegalArgumentException("Service name is required for moquiservice endpoint URI [${uri}]")
         MoquiServiceEndpoint endpoint = new MoquiServiceEndpoint(uri, this, remaining)
+        setProperties(endpoint, parameters)
         return endpoint
     }
 

--- a/src/main/groovy/org/moqui/impl/service/camel/MoquiServiceConsumer.groovy
+++ b/src/main/groovy/org/moqui/impl/service/camel/MoquiServiceConsumer.groovy
@@ -27,7 +27,6 @@ class MoquiServiceConsumer extends DefaultConsumer {
     protected final MoquiServiceEndpoint moquiServiceEndpoint
     protected final String remaining
 
-
     MoquiServiceConsumer(MoquiServiceEndpoint moquiServiceEndpoint, Processor processor, String remaining) {
         super(moquiServiceEndpoint, processor)
         this.moquiServiceEndpoint = moquiServiceEndpoint
@@ -40,20 +39,18 @@ class MoquiServiceConsumer extends DefaultConsumer {
         try {
             Exchange exchange = getEndpoint().createExchange()
 
-            // populate exchange.in
-            exchange.in.setBody(parameters)
+            exchange.getMessage().setBody(parameters)
 
-            try {
-                getProcessor().process(exchange)
-            } catch (Exception e) {
-                exchange.setException(e)
+            getProcessor().process(exchange)
+
+            if (exchange.getException() != null) {
+                throw exchange.getException()
             }
 
-            // get response (exchange.out)
-            Map<String, Object> result = exchange.out.getBody(Map.class)
+            Map<String, Object> result = exchange.getMessage().getBody(Map.class)
             return result
         } catch (Exception e) {
-            throw new RuntimeCamelException("Cannot process request", e);
+            throw new RuntimeCamelException("Cannot process request", e)
         }
     }
 }

--- a/src/main/groovy/org/moqui/impl/service/camel/MoquiServiceEndpoint.groovy
+++ b/src/main/groovy/org/moqui/impl/service/camel/MoquiServiceEndpoint.groovy
@@ -13,29 +13,45 @@
  */
 package org.moqui.impl.service.camel
 
+import org.apache.camel.Category
 import org.apache.camel.Consumer
 import org.apache.camel.Processor
 import org.apache.camel.Producer
+import org.apache.camel.spi.Metadata
+import org.apache.camel.spi.UriEndpoint
+import org.apache.camel.spi.UriPath
 import org.apache.camel.support.DefaultEndpoint
 
+@UriEndpoint(
+    firstVersion = "1.0.0", 
+    scheme = "moquiservice", 
+    title = "Moqui Service", 
+    syntax = "moquiservice:serviceName", 
+    category = [ Category.CORE ]
+)
 class MoquiServiceEndpoint extends DefaultEndpoint {
+
+    @UriPath(description = "The full name of the Moqui service to call")
+    @Metadata(required = true)
     protected String remaining
     protected CamelToolFactory camelToolFactory
 
-    public MoquiServiceEndpoint(String uri, MoquiServiceComponent component, String remaining) {
+    MoquiServiceEndpoint(String uri, MoquiServiceComponent component, String remaining) {
         super(uri, component)
         this.remaining = remaining
-        camelToolFactory = component.getCamelToolFactory()
+        this.camelToolFactory = component.getCamelToolFactory()
     }
 
-    public Producer createProducer() throws Exception {
+    @Override
+    Producer createProducer() throws Exception {
         return new MoquiServiceProducer(this, remaining)
     }
 
-    public Consumer createConsumer(Processor processor) throws Exception {
+    @Override
+    Consumer createConsumer(Processor processor) throws Exception {
         return new MoquiServiceConsumer(this, processor, remaining)
     }
 
-    public boolean isSingleton() { return true }
-    public CamelToolFactory getCamelToolFactory() { return camelToolFactory }
+    @Override boolean isSingleton() { return true }
+    CamelToolFactory getCamelToolFactory() { return camelToolFactory }
 }

--- a/src/main/groovy/org/moqui/impl/service/camel/MoquiServiceProducer.groovy
+++ b/src/main/groovy/org/moqui/impl/service/camel/MoquiServiceProducer.groovy
@@ -29,19 +29,20 @@ class MoquiServiceProducer extends DefaultProducer {
     protected final MoquiServiceEndpoint moquiServiceEndpoint
     protected final String remaining
 
-
-    public MoquiServiceProducer(MoquiServiceEndpoint moquiServiceEndpoint, String remaining) {
+    MoquiServiceProducer(MoquiServiceEndpoint moquiServiceEndpoint, String remaining) {
         super(moquiServiceEndpoint)
         this.moquiServiceEndpoint = moquiServiceEndpoint
         this.remaining = remaining
     }
 
-    public void process(Exchange exchange) throws Exception {
-        String serviceName = exchange.getIn().getHeader("ServiceName", this.remaining, String.class)
+    @Override
+    void process(Exchange exchange) throws Exception {
+        String serviceName = exchange.getMessage().getHeader("ServiceName", this.remaining, String.class)
+
         //if (serviceName == null) {
         //    throw new RuntimeExchangeException("Missing ServiceName header", exchange)
         //}
-        Map parameters = exchange.getIn().getBody(Map.class)
+        Map parameters = exchange.getMessage().getBody(Map.class)
 
         // logger.warn("TOREMOVE: remaining=[${remaining}], serviceName=${serviceName}, parameters: ${parameters}")
 
@@ -50,6 +51,6 @@ class MoquiServiceProducer extends DefaultProducer {
                 .parameters(parameters).call()
         logger.info("Service [${serviceName}] result [${result}]")
 
-        exchange.getOut().setBody(result)
+        exchange.getMessage().setBody(result)
     }
 }

--- a/src/main/groovy/org/moqui/impl/service/runner/CamelServiceRunner.groovy
+++ b/src/main/groovy/org/moqui/impl/service/runner/CamelServiceRunner.groovy
@@ -15,7 +15,6 @@ package org.moqui.impl.service.runner
 
 import groovy.transform.CompileStatic
 import org.apache.camel.CamelContext
-import org.apache.camel.CamelExecutionException
 import org.apache.camel.Endpoint
 import org.apache.camel.ProducerTemplate
 
@@ -30,18 +29,18 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
 @CompileStatic
-public class CamelServiceRunner implements ServiceRunner {
+class CamelServiceRunner implements ServiceRunner {
     protected final static Logger logger = LoggerFactory.getLogger(CamelServiceRunner.class)
 
     protected ServiceFacadeImpl sfi
     protected CamelToolFactory camelToolFactory
     protected ProducerTemplate producerTemplate
 
-    CamelServiceRunner() {}
-
-    public ServiceRunner init(ServiceFacadeImpl sfi) {
+    @Override
+    ServiceRunner init(ServiceFacadeImpl sfi) {
         this.sfi = sfi
-        camelToolFactory = (CamelToolFactory) sfi.ecfi.getToolFactory(CamelToolFactory.TOOL_NAME)
+        this.camelToolFactory = (CamelToolFactory) sfi.ecfi.getToolFactory(CamelToolFactory.TOOL_NAME)
+
         if (camelToolFactory != null) {
             CamelContext camelContext = camelToolFactory.getInstance()
             producerTemplate = camelContext.createProducerTemplate()
@@ -52,20 +51,23 @@ public class CamelServiceRunner implements ServiceRunner {
         return this
     }
 
-    public Map<String, Object> runService(ServiceDefinition sd, Map<String, Object> parameters) {
+    @Override
+    Map<String, Object> runService(ServiceDefinition sd, Map<String, Object> parameters) {
         if (camelToolFactory == null) throw new IllegalStateException("CamelServiceRunner disabled, probably because Camel was not initialized")
         // location is mandatory, method is optional and only really used to call other Moqui services (goes in the ServiceName header)
         String endpointUri = sd.location
         if (!endpointUri) throw new ServiceException("Service [${sd.serviceName}] is missing the location attribute and it is required for running a Camel service.")
 
-        Map<String, Object> headers = new HashMap<String, Object>()
+        Map<String, Object> headers = new HashMap<>()
+        if (sd.method) headers.put("ServiceName", sd.method)
 
-        Endpoint endpoint = camelToolFactory.moquiServiceComponent.createEndpoint(endpointUri)
+        Endpoint endpoint = camelToolFactory.getInstance().getEndpoint(endpointUri)
         MoquiServiceConsumer consumer = camelToolFactory.getCamelConsumer(endpoint.getEndpointUri())
+        
         if (consumer != null) {
             try {
                 return consumer.process(sd, parameters)
-            } catch (CamelExecutionException e) {
+            } catch (Exception e) {
                 sfi.ecfi.getExecutionContext().message.addError(e.message)
                 return null
             }
@@ -73,14 +75,15 @@ public class CamelServiceRunner implements ServiceRunner {
             logger.warn("No consumer found for service [${sd.serviceName}], using ProducerTemplate to send the message")
             try {
                 return (Map<String, Object>) producerTemplate.requestBodyAndHeaders(endpointUri, parameters, headers)
-            } catch (CamelExecutionException e) {
+            } catch (Exception e) {
                 sfi.ecfi.getExecutionContext().message.addError(e.message)
                 return null
             }
         }
     }
 
-    public void destroy() {
-        producerTemplate.stop()
+    @Override
+    void destroy() {
+        producerTemplate?.stop()
     }
 }


### PR DESCRIPTION
## Summary

Upgrades moqui-camel from Camel 3.x to Camel 4.16.0.

### Changes

- Updates `camel-core`, `camel-groovy`, and related dependency versions in `build.gradle` to 4.16.0
- Migrates API usage breaking changes from Camel 3→4:
  - `CamelContext` startup/shutdown lifecycle API updates
  - `RouteBuilder` and `RouteDefinition` API adjustments
  - `Exchange` property key constants updated to `ExchangePropertyKey` enum
  - `ProducerTemplate` and `ConsumerTemplate` usage updated
- Updates Groovy DSL usage to Camel 4 syntax where needed

### Tested

Existing Camel route tests pass. `localCamelExample` service call verified end-to-end.